### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To install, clone this repository into the Bundles folder.
 
 **TextMate 2**
 ```
-git clone git@github.com:ram-nadella/DashMate.tmbundle.git ~/Library/Application\ Support/Avian/Bundles/
+git clone git@github.com:ram-nadella/DashMate.tmbundle.git ~/Library/Application\ Support/Avian/Bundles/DashMate.tmbundle
 ```
 
 (Don't forget to install Dash if you don't have it already)


### PR DESCRIPTION
The current installation instructions do not create a DashMate.tmbundle folder and simply clone inside the Bundles folder, which does not work.
