### PR TITLE
Fixed populate scope bug

### DIFF
--- a/Commands/Documentation for Word : Selection.tmCommand
+++ b/Commands/Documentation for Word : Selection.tmCommand
@@ -26,7 +26,7 @@ end
 def language
   scope = ENV['TM_SCOPE']
   sources = scope.split(" ").select {|s| s.start_with? "source."}
-  source = (sources.kind_of?(Array) &amp;&amp; sources.size &gt; 1) ? sources[0] : ""
+  source = (sources.kind_of?(Array) &amp;&amp; sources.size &gt;= 1) ? sources[0] : ""
   scope_lang = source.split(".").last
 
   # convert TM source name to Dash docset keyword


### PR DESCRIPTION
Scope '<lang>:' is now being populated correctly for languages where the
scope only contains one source.<lang> string.

We now look for arrays of size 1 or greater, instead of 2 or greater.
## 

Best regards David
