### PR TITLE
Fix language detection

### DIFF
--- a/Commands/Documentation for Word : Selection.tmCommand
+++ b/Commands/Documentation for Word : Selection.tmCommand
@@ -26,7 +26,7 @@ end
 def language
   scope = ENV['TM_SCOPE']
   sources = scope.split(" ").select {|s| s.start_with? "source."}
-  source = (sources.kind_of?(Array) &amp;&amp; sources.size &gt; 1) ? sources[0] : ""
+  source = (sources.kind_of?(Array) &amp;&amp; sources.size &gt; 0) ? sources[0] : ""
   scope_lang = source.split(".").last
 
   # convert TM source name to Dash docset keyword


### PR DESCRIPTION
Language detection only worked if there was more than one scope specifier starting with "source.". However, it is sufficient for only one scope specifier to detect the language. This fix changes that.
Now lookup in e.g. Ruby source files works as expected.
